### PR TITLE
Throw less

### DIFF
--- a/ios/AlternateIcons.m
+++ b/ios/AlternateIcons.m
@@ -42,11 +42,11 @@ RCT_EXPORT_METHOD(setIconName: (NSString *)name
 RCT_EXPORT_METHOD(reset: (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject) {
     if (SYSTEM_VERSION_LESS_THAN(@"10.3")) {
-        reject(@"error", @"Alternate icons are not supported on iOS versions < 10.3", nil);
+        return resolve(@false);
     }
 
     if (![[UIApplication sharedApplication] supportsAlternateIcons]) {
-        reject(@"error", @"Alternate icons are not supported", nil);
+        return resolve(@false);
     }
 
     [[UIApplication sharedApplication] setAlternateIconName:nil

--- a/ios/AlternateIcons.m
+++ b/ios/AlternateIcons.m
@@ -62,11 +62,11 @@ RCT_EXPORT_METHOD(reset: (RCTPromiseResolveBlock)resolve
 RCT_EXPORT_METHOD(getIconName: (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject) {
     if (SYSTEM_VERSION_LESS_THAN(@"10.3")) {
-        reject(@"error", @"Alternate icons are not supported on iOS versions < 10.3", nil);
+        return resolve(@"default");
     }
 
     if (![[UIApplication sharedApplication] supportsAlternateIcons]) {
-        reject(@"error", @"Alternate icons are not supported", nil);
+        return resolve(@"default");
     }
 
     NSString *name = [[UIApplication sharedApplication] alternateIconName];

--- a/ios/AlternateIcons.m
+++ b/ios/AlternateIcons.m
@@ -22,19 +22,19 @@ RCT_EXPORT_METHOD(setIconName: (NSString *)name
                   resolver: (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject) {
     if (SYSTEM_VERSION_LESS_THAN(@"10.3")) {
-        reject(@"error", @"Alternate icons are not supported on iOS versions < 10.3", nil);
+        return reject(@"error", @"Alternate icons are not supported on iOS versions < 10.3", nil);
     }
 
     if (![[UIApplication sharedApplication] supportsAlternateIcons]) {
-        reject(@"error", @"Alternate icons are not supported", nil);
+        return reject(@"error", @"Alternate icons are not supported", nil);
     }
 
     [[UIApplication sharedApplication] setAlternateIconName:name
                                           completionHandler:^(NSError *_Nullable error) {
                                               if (error != nil) {
-                                                  reject(@"error", @"Problem changing the icon", error);
+                                                  return reject(@"error", @"Problem changing the icon", error);
                                               } else {
-                                                  resolve(@true);
+                                                  return resolve(@true);
                                               }
                                           }];
 }
@@ -52,9 +52,9 @@ RCT_EXPORT_METHOD(reset: (RCTPromiseResolveBlock)resolve
     [[UIApplication sharedApplication] setAlternateIconName:nil
                                           completionHandler:^(NSError *_Nullable error) {
                                               if (error != nil) {
-                                                  reject(@"error", @"Problem changing the icon", error);
+                                                  return reject(@"error", @"Problem changing the icon", error);
                                               } else {
-                                                  resolve(@true);
+                                                  return resolve(@true);
                                               }
                                           }];
 }
@@ -73,20 +73,18 @@ RCT_EXPORT_METHOD(getIconName: (RCTPromiseResolveBlock)resolve
     if (name == nil) {
         name = @"default";
     }
-    resolve(name);
+    return resolve(name);
 }
 
 RCT_EXPORT_METHOD(isSupported: (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject) {
     if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.3")) {
         if ([[UIApplication sharedApplication] supportsAlternateIcons]) {
-            resolve(@YES);
-        } else {
-            resolve(@NO);
+            return resolve(@YES);
         }
-    } else {
-        resolve(@NO);
+        return resolve(@NO);
     }
+    return resolve(@NO);
 }
 
 @end

--- a/module.ios.js
+++ b/module.ios.js
@@ -7,7 +7,7 @@ export function setIconName(name: string): Promise<void> {
     return AlternateIcons.setIconName(name);
 }
 
-export function reset(): Promise<void> {
+export function reset(): Promise<boolean> {
     return AlternateIcons.reset();
 }
 


### PR DESCRIPTION
A few things:

- Remove many of the `rejects` that would happen when functions were called on old iOS versions
- Return `"default"` from getIconName when alternate icons are unavailable
